### PR TITLE
fix(components): Paint sheet spring-overshoot filler from the surface token

### DIFF
--- a/.changeset/overlay-sheet-spring-fill.md
+++ b/.changeset/overlay-sheet-spring-fill.md
@@ -1,0 +1,5 @@
+---
+'@ethlete/components': patch
+---
+
+Overlay sheets: the filler strip that hides the sheet's spring-overshoot now paints from the surface token (`--et-surface-background-solid`) instead of `inherit`. Sheets whose background is painted on nested content (e.g. a date picker) left the container host transparent, so during the enter-spring overshoot the momentary gap at the docked edge revealed the page background. It now paints the matching surface color.

--- a/libs/components/src/lib/overlay/overlay-container.component.css
+++ b/libs/components/src/lib/overlay/overlay-container.component.css
@@ -268,10 +268,17 @@
   }
 
   .et-overlay.et-with-default-animation {
+    /* Filler strip that hides the sheet's spring overshoot: it hangs just past the docked
+     edge (see the per-direction insets below) and must paint the same color as the sheet's
+     surface so the momentary gap never reveals the page behind it. Source it from the surface
+     token — which the container always forces onto the host by elevation — rather than
+     `inherit`, because most sheet content (e.g. a date picker) paints its background on a nested
+     element, leaving the host transparent; `inherit` would then paint nothing and the overshoot
+     shows through. `inherit` stays as the fallback for overlays opened without surface themes. */
     &::after {
       content: '';
       position: absolute;
-      background-color: inherit;
+      background-color: var(--et-surface-background-solid, inherit);
     }
 
     &.et-overlay--full-screen-dialog {


### PR DESCRIPTION
## Problem

Overlay sheets animate in with a spring (`--ease-spring-1`) that overshoots ~1.7% past its resting position, briefly lifting the docked edge off the viewport. The `::after` filler strip meant to cover that gap painted with `background-color: inherit`, i.e. the container **host's** background. Most sheet content (e.g. a date picker) paints its surface on a **nested** element, leaving the host transparent — so the strip was transparent and the overshoot revealed the page background behind the sheet.

## Fix

Source the filler from the surface token the container always forces onto the host by elevation (`--et-surface-background-solid`), with `inherit` as fallback for overlays opened without surface themes. Verified live against Storybook: the token resolves to the sheet's themed surface color and matches the nested content surface (same surface context), so the gap fills seamlessly. Zero-JS, keeps the spring, and the strip sits at the squared docked edge so there's no rounded-corner artifact. The base rule is shared with dialogs, whose `::after` has no size — so the color change is a no-op there.