### PR TITLE
fix(components): Paint sheet overshoot filler with a box-shadow so overflow:hidden can't clip it

### DIFF
--- a/.changeset/overlay-sheet-spring-fill.md
+++ b/.changeset/overlay-sheet-spring-fill.md
@@ -2,4 +2,4 @@
 '@ethlete/components': patch
 ---
 
-Overlay sheets: the filler strip that hides the sheet's spring-overshoot now paints from the surface token (`--et-surface-background-solid`) instead of `inherit`. Sheets whose background is painted on nested content (e.g. a date picker) left the container host transparent, so during the enter-spring overshoot the momentary gap at the docked edge revealed the page background. It now paints the matching surface color.
+Overlay sheets: fix the black gap that appeared at the docked edge while a sheet sprang into view. The enter spring overshoots slightly past the docked edge, and the filler meant to cover that gap was an `::after` strip positioned just outside the host — which sheets clip away with their `overflow: hidden` (kept for the rounded corners), so nothing painted and the page background showed through (most visible with sheets whose surface is painted on nested content, e.g. the date picker). The filler is now a solid offset `box-shadow` in the surface color, which is not clipped by the host's own overflow and needs no change to the corner clipping.

--- a/libs/components/src/lib/overlay/overlay-container.component.css
+++ b/libs/components/src/lib/overlay/overlay-container.component.css
@@ -268,18 +268,12 @@
   }
 
   .et-overlay.et-with-default-animation {
-    /* Filler strip that hides the sheet's spring overshoot: it hangs just past the docked
-     edge (see the per-direction insets below) and must paint the same color as the sheet's
-     surface so the momentary gap never reveals the page behind it. Source it from the surface
-     token — which the container always forces onto the host by elevation — rather than
-     `inherit`, because most sheet content (e.g. a date picker) paints its background on a nested
-     element, leaving the host transparent; `inherit` would then paint nothing and the overshoot
-     shows through. `inherit` stays as the fallback for overlays opened without surface themes. */
-    &::after {
-      content: '';
-      position: absolute;
-      background-color: var(--et-surface-background-solid, inherit);
-    }
+    /* Color of the overshoot filler painted past a sheet's docked edge (see the per-direction
+     box-shadows below). Sourced from the surface token — which the container always forces onto
+     the host by elevation — because most sheet content (e.g. a date picker) paints its background
+     on a nested element, leaving the host itself transparent, so `inherit` would paint nothing.
+     Falls back to transparent (no filler) for overlays opened without surface themes. */
+    --_et-overlay-overshoot-fill: var(--et-surface-background-solid, transparent);
 
     &.et-overlay--full-screen-dialog {
       &.et-animation-enter-from,
@@ -353,11 +347,12 @@
         transition: transform 150ms var(--ease-in-5);
       }
 
-      &::after {
-        inset-inline: 0;
-        inset-block-end: -50px;
-        block-size: 50px;
-      }
+      /* Hide the spring overshoot: the sheet momentarily springs past its docked edge, which
+       would reveal the page behind it. A solid, zero-blur offset box-shadow paints a 50px block
+       just past that edge in the surface color, filling the gap. A shadow (not a pseudo-element)
+       is used deliberately: sheets keep `overflow: hidden` to clip their rounded corners, and an
+       element's own box-shadow is not clipped by its own overflow — a child/`::after` would be. */
+      box-shadow: 0 50px 0 0 var(--_et-overlay-overshoot-fill);
     }
 
     &.et-overlay--top-sheet {
@@ -378,11 +373,7 @@
         transition: transform 150ms var(--ease-in-5);
       }
 
-      &::after {
-        inset-inline: 0;
-        inset-block-start: -50px;
-        block-size: 50px;
-      }
+      box-shadow: 0 -50px 0 0 var(--_et-overlay-overshoot-fill);
     }
 
     &.et-overlay--left-sheet {
@@ -403,11 +394,7 @@
         transition: transform 150ms var(--ease-in-5);
       }
 
-      &::after {
-        inset-inline-start: -50px;
-        inset-block: 0;
-        inline-size: 50px;
-      }
+      box-shadow: -50px 0 0 0 var(--_et-overlay-overshoot-fill);
     }
 
     &.et-overlay--right-sheet {
@@ -428,11 +415,7 @@
         transition: transform 150ms var(--ease-in-5);
       }
 
-      &::after {
-        inset-inline-end: -50px;
-        inset-block: 0;
-        inline-size: 50px;
-      }
+      box-shadow: 50px 0 0 0 var(--_et-overlay-overshoot-fill);
     }
 
     &.et-overlay--dialog {


### PR DESCRIPTION
## Problem

Overlay sheets spring in with a slight overshoot past their docked edge, briefly exposing the page behind them (the black bar seen under a date-picker bottom sheet). The filler that was supposed to cover that was an `::after` strip positioned *outside* the host (`inset-block-end: -50px`). But sheets keep `overflow: hidden` (to clip their rounded corners), and a host's own `overflow: hidden` **clips its descendants** — so the `::after` strip was clipped away and never painted. This was most visible with sheets whose surface is painted on nested content (e.g. `.et-date-picker-panel`), leaving the container host transparent.

(The demo overlay story appeared fine only because its content is `.et-overlay-main`, which flips the host to `overflow: visible`.)

## Fix

Replace the `::after` strip with a solid, zero-blur **offset box-shadow** in the surface color, one per sheet direction. An element's own `box-shadow` is **not** clipped by its own `overflow`, so the fill paints past the docked edge with the rounded-corner clipping left completely untouched. Color comes from `--et-surface-background-solid` (fallback transparent), so it matches nested-painted surfaces.

Verified live against the real date-picker bottom sheet in Storybook: overshoot gap filled, rounded top corners intact.

Supersedes the color-only attempt in #3025 (which was necessary but insufficient — the strip was clipped regardless of its color).