### PR TITLE
fix(query): Stop legacy interop mutations throwing ET301

### DIFF
--- a/.changeset/legacy-mutation-allow-cache.md
+++ b/.changeset/legacy-mutation-allow-cache.md
@@ -1,0 +1,16 @@
+---
+'@ethlete/query': patch
+---
+
+Fix `ET301` on every legacy interop mutation. `LegacyQuery.execute()` translates v2's single `skipCache` into
+`allowCache: options.skipCache !== true` for **every** method, so any `legacyPost*` / `legacyPut*` /
+`legacyPatch*` / `legacyDelete*` executed without an explicit `skipCache: true` reached the repository with
+`allowCache: true` and threw "This request is uncacheable, but allowCache is set to true".
+
+`allowCache` is never read on the uncacheable path — there is no cache entry to reuse — so the throw was purely a
+guard against a mistake in hand-written code. It stays for that, and gains a
+`silenceUncacheableAllowCacheError` opt-out on `QueryConfig`, which `createLegacyQueryCreator` sets alongside the
+`silenceMissingWithArgsFeatureError` it already passed. The cache-key guard is unaffected.
+
+Note that dropping `allowCache: true` in the interop instead would have silently made every legacy `GET` refetch,
+since an absent `allowCache` means "do not reuse the entry" rather than "use the default".

--- a/libs/query/src/lib/http/query-creator.ts
+++ b/libs/query/src/lib/http/query-creator.ts
@@ -184,6 +184,16 @@ export type QueryConfig = {
   silenceMissingWithArgsFeatureError?: boolean;
 
   /**
+   * If true, executing with `allowCache` on a request that cannot be cached is ignored instead of throwing
+   * `ET301`.
+   *
+   * For the legacy interop layer: v2 had a single `skipCache` for every method, so it forwards `allowCache`
+   * without being able to tell a cacheable request from an uncacheable one. Application code should not set
+   * this — on a hand-written `execute()` the error it silences is a real mistake.
+   */
+  silenceUncacheableAllowCacheError?: boolean;
+
+  /**
    * A custom injector to use for this query.
    */
   injector?: Injector;

--- a/libs/query/src/lib/http/query-execute-utils.ts
+++ b/libs/query/src/lib/http/query-execute-utils.ts
@@ -63,6 +63,7 @@ export const queryExecute = <TArgs extends QueryArgs>(options: QueryExecuteOptio
     previousKey: executeState.previousKey(),
     runQueryOptions,
     isSecure,
+    silenceUncacheableAllowCacheError: queryConfig.silenceUncacheableAllowCacheError,
   });
 
   executeState.previousKey.set(key);

--- a/libs/query/src/lib/http/query-repository.spec.ts
+++ b/libs/query/src/lib/http/query-repository.spec.ts
@@ -137,9 +137,34 @@ describe('createQueryRepository', () => {
     ).toThrow();
   });
 
+  it('should not throw if allowCache is used on a uncacheable request with silenceUncacheableAllowCacheError', () => {
+    expect(() =>
+      repo.request({
+        consumerDestroyRef: destroyRef,
+        method: 'POST',
+        route: '/test',
+        runQueryOptions: { allowCache: true },
+        silenceUncacheableAllowCacheError: true,
+      }),
+    ).not.toThrow();
+  });
+
   it('should throw if key is used on a uncacheable request', () => {
     expect(() =>
       repo.request({ consumerDestroyRef: destroyRef, method: 'POST', route: '/test', key: 'my_key' }),
+    ).toThrow();
+  });
+
+  it('should still throw if key is used on a uncacheable request with silenceUncacheableAllowCacheError', () => {
+    expect(() =>
+      repo.request({
+        consumerDestroyRef: destroyRef,
+        method: 'POST',
+        route: '/test',
+        key: 'my_key',
+        runQueryOptions: { allowCache: true },
+        silenceUncacheableAllowCacheError: true,
+      }),
     ).toThrow();
   });
 

--- a/libs/query/src/lib/http/query-repository.ts
+++ b/libs/query/src/lib/http/query-repository.ts
@@ -69,6 +69,9 @@ export type QueryRepositoryRequestOptions<TArgs extends QueryArgs> = {
 
   /** Configuration on how to run the query */
   runQueryOptions?: RunQueryExecuteOptions;
+
+  /** @see QueryConfig.silenceUncacheableAllowCacheError */
+  silenceUncacheableAllowCacheError?: boolean;
 };
 
 export type QueryRepositoryItem<TArgs extends QueryArgs> = {
@@ -240,7 +243,12 @@ export const createQueryRepository = (config: CreateQueryRepositoryConfig): Quer
         : shouldCacheQuery(options.method) || creatorOptions?.subtle?.useQueryRepositoryCache === true;
 
     if (!shouldCache && options.key) throw uncacheableRequestHasCacheKeyParam(options.key);
-    if (!shouldCache && runQueryOptions?.allowCache) throw uncacheableRequestHasAllowCacheParam();
+
+    // `allowCache` is never read on the uncacheable path below — there is no cache entry to reuse — so this throw
+    // is purely a guard against a mistake in hand-written code. The legacy interop opts out of it.
+    if (!shouldCache && runQueryOptions?.allowCache && !options.silenceUncacheableAllowCacheError) {
+      throw uncacheableRequestHasAllowCacheParam();
+    }
 
     const route = buildRoute({
       base: config.baseUrl,

--- a/libs/query/src/lib/legacy/interop/legacy-query-creator.ts
+++ b/libs/query/src/lib/legacy/interop/legacy-query-creator.ts
@@ -171,6 +171,8 @@ export class LegacyQueryCreator<
           onlyManualExecution: true,
           injector,
           silenceMissingWithArgsFeatureError: true,
+          // `LegacyQuery.execute()` forwards v2's `skipCache` as `allowCache` for every method, cacheable or not.
+          silenceUncacheableAllowCacheError: true,
         });
 
         const legacyQuery = new LegacyQuery<

--- a/libs/query/src/lib/legacy/interop/legacy-query.ts
+++ b/libs/query/src/lib/legacy/interop/legacy-query.ts
@@ -287,6 +287,9 @@ export class LegacyQuery<
 
   execute(options: ExecuteQueryOptions = {}) {
     untracked(() =>
+      // v2 had a single `skipCache` for every method, so this cannot tell whether the underlying request is
+      // cacheable. The creator is built with `silenceUncacheableAllowCacheError`, which makes `allowCache` inert
+      // on a mutation instead of throwing ET301.
       this.newQuery.execute({ args: this._arguments, options: { allowCache: options.skipCache !== true } }),
     );
 


### PR DESCRIPTION
`LegacyQuery.execute()` translates v2's single `skipCache` into `allowCache: options.skipCache !== true` for every method, so any legacy POST/PUT/PATCH/DELETE executed without an explicit `skipCache: true` reached the repository with `allowCache: true` and threw ET301 ("This request is uncacheable, but allowCache is set to true"). That is every mutation in a migrated workspace — 142 legacy mutation creators across ~318 files in the one this was found in.

`allowCache` is never read on the uncacheable path: `cacheKey` is `false`, the cache-reuse block is skipped and `request.execute()` is called with no options. So the throw is purely a guard against a mistake in hand-written code. It stays for that, and gains a `silenceUncacheableAllowCacheError` opt-out on `QueryConfig`, which `createLegacyQueryCreator` sets alongside the `silenceMissingWithArgsFeatureError` it already passed. The cache-key guard is deliberately unaffected.

Dropping `allowCache: true` in the interop instead would have silently made every legacy GET refetch, since an absent `allowCache` means "do not reuse the entry" rather than "use the default".